### PR TITLE
Remove chat header to revert to cleaner UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,23 +67,6 @@
 
             <!-- Main Chat Area -->
             <main class="chat-main">
-                <!-- Chat Header -->
-                <div class="chat-header">
-                    <div class="chat-header-icon">
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-                        </svg>
-                    </div>
-                    <div class="chat-header-text">
-                        <h1>Course Materials Assistant</h1>
-                        <p>Ask about courses, lessons, and content</p>
-                    </div>
-                    <div class="chat-header-status">
-                        <span class="status-dot"></span>
-                        Online
-                    </div>
-                </div>
-
                 <div class="chat-container">
                     <div id="chatMessages" class="chat-messages"></div>
                     <div class="chat-input-container">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -361,64 +361,6 @@ details[open] .suggested-header::before {
     background: var(--background);
 }
 
-/* Chat header bar */
-.chat-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.85rem 2rem;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
-    flex-shrink: 0;
-}
-
-.chat-header-icon {
-    width: 36px;
-    height: 36px;
-    background: linear-gradient(135deg, #6366f1, #8b5cf6);
-    border-radius: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: white;
-    font-size: 1.1rem;
-    flex-shrink: 0;
-}
-
-.chat-header-text h1 {
-    font-size: 0.95rem;
-    font-weight: 700;
-    color: var(--text-primary);
-    letter-spacing: -0.01em;
-}
-
-.chat-header-text p {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-}
-
-.chat-header-status {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-}
-
-.status-dot {
-    width: 8px;
-    height: 8px;
-    background: #22c55e;
-    border-radius: 50%;
-    animation: pulse-dot 2s infinite;
-}
-
-@keyframes pulse-dot {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.5; }
-}
-
 /* Chat Container */
 .chat-container {
     flex: 1;
@@ -821,10 +763,6 @@ details[open] .suggested-header::before {
 
     .chat-main {
         order: 1;
-    }
-
-    .chat-header {
-        padding: 0.75rem 1rem;
     }
 
     .chat-messages {


### PR DESCRIPTION
Fixes #2

Reverted the header by removing the chat header section as requested:
- Removed "Course Materials Assistant" header
- Removed subheader "Ask about courses, lessons, and content"
- Removed horizontal row below the subheader
- Removed all associated CSS styling

The chat interface now has a cleaner look with the chat area starting directly with the chat container.

---
Generated with [Claude Code](https://claude.ai/code)